### PR TITLE
A naive approach to solve problem of false positives on `.alive?`

### DIFF
--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -3,9 +3,13 @@ module SidekiqAlive
     include Sidekiq::Worker
     sidekiq_options retry: false
 
-    def perform
-      write_living_probe
-      self.class.perform_in(SidekiqAlive.time_to_live / 2)
+    def perform(alive_key)
+      if(alive_key == SidekiqAlive.liveness_key)
+        write_living_probe
+        self.class.perform_in(SidekiqAlive.time_to_live / 2, SidekiqAlive.liveness_key)
+      else
+        self.class.perform_async(alive_key)
+      end
     end
 
     def write_living_probe

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,15 +1,29 @@
 RSpec.describe SidekiqAlive::Worker do
   subject do
     n = described_class.new
-    n.perform
+    n.perform(SidekiqAlive.liveness_key)
   end
 
   it 'calls to main methods in SidekiqAlive' do
-    expect(described_class).to receive(:perform_in)#.with(instance_of(Integer))
+    expect(described_class).to receive(:perform_in).with(instance_of(Fixnum), SidekiqAlive.liveness_key)
     expect(SidekiqAlive).to receive(:store_alive_key).once
     n = 0
-    expect(SidekiqAlive).to   receive(:callback).once.and_return(proc { n = 2 })
+    expect(SidekiqAlive).to receive(:callback).once.and_return(proc { n = 2 })
     subject
     expect(n).to eq 2
+  end
+
+  context 'when the job belongs to another container' do
+    subject do
+      n = described_class.new
+      n.perform('some_other_key')
+    end
+
+    it 'does not write the liveliness key' do
+      expect(described_class).to receive(:perform_async).with('some_other_key')
+      expect(SidekiqAlive).to receive(:store_alive_key).never
+      expect(SidekiqAlive).to receive(:callback).never
+      subject
+    end
   end
 end


### PR DESCRIPTION
This approach tries to resolves the issue where multiple containers are
running sidekiq in a given cluster but only a single container is
actually processing work. The intent here is that you configure each
container to to use a unique liveness key and only update the alive key
when a work process a job for it's own container. This will now always
work and an approach that uses a unique key per container may be better.