### PR TITLE
Use retry to get to other hosts

### DIFF
--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -1,14 +1,15 @@
 module SidekiqAlive
   class Worker
     include Sidekiq::Worker
-    sidekiq_options retry: false
+    sidekiq_options retry: 20
+    sidekiq_retry_in { |count| 1 }
 
     def perform(alive_key)
       if(alive_key == SidekiqAlive.liveness_key)
         write_living_probe
         self.class.perform_in(SidekiqAlive.time_to_live / 2, SidekiqAlive.liveness_key)
       else
-        self.class.perform_async(alive_key)
+        raise StandardError, "Not the correct host, will retry"
       end
     end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -20,10 +20,9 @@ RSpec.describe SidekiqAlive::Worker do
     end
 
     it 'does not write the liveliness key' do
-      expect(described_class).to receive(:perform_async).with('some_other_key')
       expect(SidekiqAlive).to receive(:store_alive_key).never
       expect(SidekiqAlive).to receive(:callback).never
-      subject
+      expect { subject }.to raise_error(StandardError, "Not the correct host, will retry")
     end
   end
 end


### PR DESCRIPTION
I'm thinking that a dynamic queue in each sidekiq config might be the best option but for now going with this.